### PR TITLE
Remove `site_id` field

### DIFF
--- a/help_desk_api/serializers.py
+++ b/help_desk_api/serializers.py
@@ -347,7 +347,6 @@ class ZendeskToHaloCreateTicketSerializer(serializers.Serializer):
     }
     """
 
-    # site_id = serializers.IntegerField(default=18)
     summary = HaloSummaryFromZendeskField()
     details = HaloDetailsFromZendeskField()
     tags = HaloTagsFromZendeskField(required=False)

--- a/help_desk_api/serializers.py
+++ b/help_desk_api/serializers.py
@@ -347,7 +347,7 @@ class ZendeskToHaloCreateTicketSerializer(serializers.Serializer):
     }
     """
 
-    site_id = serializers.IntegerField(default=18)
+    # site_id = serializers.IntegerField(default=18)
     summary = HaloSummaryFromZendeskField()
     details = HaloDetailsFromZendeskField()
     tags = HaloTagsFromZendeskField(required=False)

--- a/tests/halo_api/test_zendesk_to_halo_transformation.py
+++ b/tests/halo_api/test_zendesk_to_halo_transformation.py
@@ -24,13 +24,6 @@ class TestZendeskToHaloSerialization:
             with pytest.raises(ZendeskFieldsNotSupportedException):
                 serializer_field.to_representation({"id": 1, "value": "foo"})
 
-    def test_site_id_in_serialisation(self, zendesk_ticket_subject_and_comment_only):
-        serializer = ZendeskToHaloCreateTicketSerializer()
-
-        halo_equivalent = serializer.to_representation(zendesk_ticket_subject_and_comment_only)
-
-        assert "site_id" in halo_equivalent
-
     def test_zendesk_custom_field_to_halo_custom_field(self):
         with mock.patch.dict(
             "help_desk_api.serializers.halo_mappings_by_zendesk_id",


### PR DESCRIPTION
Default value for `site_id` should be configured in Halo, so there's no need to add it in the serialiser.