### PR TITLE
Make sure no search robots index the healthcheck.

### DIFF
--- a/healthcheck/middleware.py
+++ b/healthcheck/middleware.py
@@ -12,4 +12,5 @@ class StatsMiddleware:
         response_time = time.time() - request.start_time
         response.context_data["response_time"] = response_time
         response["Cache-Control"] = "no-cache, no-store, must-revalidate"  # /PS-IGNORE
+        response["X-Robots-Tag"] = "noindex"
         return response

--- a/tests/healthcheck/test_healthcheck.py
+++ b/tests/healthcheck/test_healthcheck.py
@@ -84,3 +84,10 @@ class TestHealthCheckResponses:
         assert (
             response.headers["Cache-Control"] == "no-cache, no-store, must-revalidate"  # /PS-IGNORE
         )
+
+    @mock.patch("healthcheck.views.HelpDeskCreds")
+    def test_response_robots_noindex_header(self, mock_help_desk_creds, client):
+        response = client.get(reverse("healthcheck"))
+
+        assert "X-Robots-Tag" in response.headers  # /PS-IGNORE
+        assert response.headers["X-Robots-Tag"] == "noindex"  # /PS-IGNORE


### PR DESCRIPTION
Required for 1st Go Live checklist. The only thing that might get indexed is the healthcheck, so this puts a stop to that.