### PR TITLE
Fix Sentry irritation.

### DIFF
--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -3,8 +3,28 @@ from sentry_sdk.integrations.django import DjangoIntegration
 
 from config.settings.base import *  # type: ignore # noqa
 
+
+def strip_handled_exceptions(event, _hint):
+    # Ignore logged errors
+    if "logger" in event:
+        return None
+
+    # Ignore handled exceptions
+    exceptions = event.get("exception", {}).get("values", [])
+    if exceptions:
+        exc = exceptions[-1]
+        mechanism = exc.get("mechanism")
+
+        if mechanism:
+            if mechanism.get("handled"):
+                return None
+
+    return event
+
+
 sentry_sdk.init(
     os.environ.get("SENTRY_DSN"),
     environment=os.environ.get("SENTRY_ENVIRONMENT"),
     integrations=[DjangoIntegration()],
+    before_send=strip_handled_exceptions,
 )


### PR DESCRIPTION
Sentry insists on logging internal exceptions that have been handled. This means that a request to the admin, which causes a 401 Unauthorized which is then disposed of at a higher level, appears in the Sentry logs as an error with a tin y "Handled" label that you can only see by viewing the detail page. So this is to stop it doing that.