### PR TITLE
TS2-342: Dual-running exception handling

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -521,3 +521,4 @@ dontackemails2
 the Zendesk API's
 POST User
 Django 4.2.14
+Test Halo

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,6 +176,31 @@ def new_zendesk_ticket_with_comment():
     }
 
 
+@pytest.fixture()
+def new_zendesk_ticket_with_unknown_field():
+    """
+    This is an example of the ticket submission for a
+    new dataset request
+    on Data Workspace  /PS-IGNORE
+    """
+    return {
+        "comment": {
+            "body": "Long load of text here",
+        },
+        "subject": "Request for new dataset on Data Workspace",  # /PS-IGNORE
+        "tags": [
+            "request-for-data",
+            "another-tag",
+        ],
+        "recipient": "someone@example.gov.uk",  # /PS-IGNORE
+        "requester": {"name": "Some Body", "email": "somebody@example.com"},  # /PS-IGNORE
+        "custom_fields": [
+            {"id": 31281329, "value": "data_workspace"},
+        ],
+        "unknown_field_1234": "abc",
+    }
+
+
 @pytest.fixture(scope="session")
 def new_zendesk_ticket_with_uploads():
     """

--- a/tests/zendesk_api_proxy/conftest.py
+++ b/tests/zendesk_api_proxy/conftest.py
@@ -82,6 +82,20 @@ def zendesk_create_ticket_request(
 
 
 @pytest.fixture()
+def zendesk_create_ticket_request_with_unknown_field(
+    zendesk_authorization_header, new_zendesk_ticket_with_unknown_field, rf: RequestFactory
+):
+    url = reverse("api:tickets")
+    request = rf.post(
+        url,
+        data=new_zendesk_ticket_with_unknown_field,
+        content_type="application/json",
+        headers={"Authorization": zendesk_authorization_header},
+    )
+    return request
+
+
+@pytest.fixture()
 def zendesk_create_ticket_response_body():
     # Heavily cut down
     return {

--- a/tests/zendesk_api_proxy/test_dual_running.py
+++ b/tests/zendesk_api_proxy/test_dual_running.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock
 from django.http import HttpResponse
 from django.urls import reverse
 
+from help_desk_api.serializers import ZendeskFieldsNotSupportedException
+
 
 @mock.patch("halo.halo_manager.HaloAPIClient._HaloAPIClient__authenticate", return_value="abc123")
 @mock.patch("zendesk_api_proxy.middleware.ZendeskAPIProxyMiddleware.make_zendesk_request")
@@ -57,3 +59,59 @@ class TestDualRunningExceptionHandling:
         )
 
         assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+
+    def test_dual_running_halo_unknown_field_error_allows_valid_zendesk_response(
+        self,
+        mock_make_halo_request: MagicMock,
+        mock_make_zendesk_request: MagicMock,
+        _mock_halo_authenticate: MagicMock,
+        zendesk_create_ticket_request_with_unknown_field,
+        zendesk_create_ticket_response,
+        zendesk_authorization_header,
+        zendesk_and_halo_creds,
+        client,
+    ):
+        """
+        Halo has a special error for unrecognised fields, which is handled separately
+        so we test for that path with this.
+        """
+        mock_make_zendesk_request.return_value = zendesk_create_ticket_response
+        mock_make_halo_request.side_effect = ZendeskFieldsNotSupportedException("Test Halo error")
+        url = reverse("api:tickets")
+
+        response: HttpResponse = client.post(
+            url,
+            data=zendesk_create_ticket_request_with_unknown_field,
+            headers={"Authorization": zendesk_authorization_header},
+            content_type="application/json",
+        )
+
+        assert response.status_code == HTTPStatus.CREATED
+
+    def test_single_running_halo_unknown_field_error_returns_error_response(
+        self,
+        mock_make_halo_request: MagicMock,
+        mock_make_zendesk_request: MagicMock,
+        _mock_halo_authenticate: MagicMock,
+        zendesk_create_ticket_request_with_unknown_field,
+        zendesk_create_ticket_response,
+        zendesk_authorization_header,
+        halo_creds_only,
+        client,
+    ):
+        """
+        Halo has a special error for unrecognised fields, which is handled separately
+        so we test for that path with this.
+        """
+        mock_make_zendesk_request.return_value = zendesk_create_ticket_response
+        mock_make_halo_request.side_effect = ZendeskFieldsNotSupportedException("Test Halo error")
+        url = reverse("api:tickets")
+
+        response: HttpResponse = client.post(
+            url,
+            data=zendesk_create_ticket_request_with_unknown_field,
+            headers={"Authorization": zendesk_authorization_header},
+            content_type="application/json",
+        )
+
+        assert response.status_code == HTTPStatus.BAD_REQUEST

--- a/tests/zendesk_api_proxy/test_dual_running.py
+++ b/tests/zendesk_api_proxy/test_dual_running.py
@@ -1,0 +1,59 @@
+from http import HTTPStatus
+from unittest import mock
+from unittest.mock import MagicMock
+
+from django.http import HttpResponse
+from django.urls import reverse
+
+
+@mock.patch("halo.halo_manager.HaloAPIClient._HaloAPIClient__authenticate", return_value="abc123")
+@mock.patch("zendesk_api_proxy.middleware.ZendeskAPIProxyMiddleware.make_zendesk_request")
+@mock.patch("zendesk_api_proxy.middleware.ZendeskAPIProxyMiddleware.make_halo_request")
+class TestDualRunningExceptionHandling:
+    def test_dual_running_halo_error_allows_valid_zendesk_response(
+        self,
+        mock_make_halo_request: MagicMock,
+        mock_make_zendesk_request: MagicMock,
+        _mock_halo_authenticate: MagicMock,
+        zendesk_create_ticket_request,
+        zendesk_create_ticket_response,
+        zendesk_authorization_header,
+        zendesk_and_halo_creds,
+        client,
+    ):
+        mock_make_zendesk_request.return_value = zendesk_create_ticket_response
+        mock_make_halo_request.side_effect = Exception("Test Halo error")
+        url = reverse("api:tickets")
+
+        response: HttpResponse = client.post(
+            url,
+            data=zendesk_create_ticket_request,
+            headers={"Authorization": zendesk_authorization_header},
+            content_type="application/json",
+        )
+
+        assert response.status_code == HTTPStatus.CREATED
+
+    def test_single_running_halo_error_returns_error_response(
+        self,
+        mock_make_halo_request: MagicMock,
+        mock_make_zendesk_request: MagicMock,
+        _mock_halo_authenticate: MagicMock,
+        zendesk_create_ticket_request,
+        zendesk_create_ticket_response,
+        zendesk_authorization_header,
+        halo_creds_only,
+        client,
+    ):
+        mock_make_zendesk_request.return_value = zendesk_create_ticket_response
+        mock_make_halo_request.side_effect = Exception("Test Halo error")
+        url = reverse("api:tickets")
+
+        response: HttpResponse = client.post(
+            url,
+            data=zendesk_create_ticket_request,
+            headers={"Authorization": zendesk_authorization_header},
+            content_type="application/json",
+        )
+
+        assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR


### PR DESCRIPTION
Ensure Halo errors are handled such that Zendesk responses are still sent when dual-running.